### PR TITLE
Fixed network manager memory leak.

### DIFF
--- a/SpaceDash/Model/NetworkManager.swift
+++ b/SpaceDash/Model/NetworkManager.swift
@@ -8,14 +8,14 @@
 
 import Foundation
 
-protocol NetworkManagerDelegate {
+protocol NetworkManagerDelegate: AnyObject {
     func updateFromAPI( data: Any)
     func error( error: Error)
 }
 
 struct NetworkManager{
     
-    var delegate:NetworkManagerDelegate?
+    weak var delegate:NetworkManagerDelegate?
     var key : String = " "
     
     


### PR DESCRIPTION
Fixed memory leak caused by the network manager. This PR is for solving the issue #39 

![Screenshot 2020-10-02 at 5 18 11 PM](https://user-images.githubusercontent.com/12982964/94920111-42303c00-04d3-11eb-89a3-9d98aefaa4d8.png)

you can see the #transient objects reflecting the objects released from the memory
